### PR TITLE
Fix science duplication

### DIFF
--- a/KSPArchipelago/ArchipelagoUI.cs
+++ b/KSPArchipelago/ArchipelagoUI.cs
@@ -179,15 +179,9 @@ namespace KSPArchipelago
             GUILayout.Space(8);
             if (GUILayout.Button("Re-award All Items"))
             {
-                var scenario = ApScenarioModule.Instance;
-                if (scenario != null && ResearchAndDevelopment.Instance != null)
-                {
-                    // Undo all previously awarded science.
-                    ResearchAndDevelopment.Instance.AddScience(
-                        -scenario.TotalApScienceAwarded, TransactionReasons.Cheating);
-                    scenario.TotalApScienceAwarded = 0;
-                    scenario.AwardedItemIndices.Clear();
-                }
+                // Do NOT touch science or AwardedItemIndices here. ProcessAllItems
+                // skips science for indices already in AwardedItemIndices, so
+                // science the player has already spent is preserved.
                 KSPArchipelagoPartsManager.ScrubTechTree();
                 KSPArchipelagoPartsManager.ClearAllExperimentalParts();
                 mod.ResetProgressiveState();

--- a/KSPArchipelago/ArchipelagoUI.cs
+++ b/KSPArchipelago/ArchipelagoUI.cs
@@ -179,9 +179,24 @@ namespace KSPArchipelago
             GUILayout.Space(8);
             if (GUILayout.Button("Re-award All Items"))
             {
-                // Do NOT touch science or AwardedItemIndices here. ProcessAllItems
-                // skips science for indices already in AwardedItemIndices, so
-                // science the player has already spent is preserved.
+                var scenario = ApScenarioModule.Instance;
+                if (scenario != null && mod.Session != null)
+                {
+                    // Remove only non-science indices from AwardedItemIndices
+                    // ProcessAllItems will re-process parts/progressives as new
+                    // (showing toasts, re-adding them to the editor), while science
+                    // indices stay in the set so science is not re-awarded
+                    var allItems = mod.Session.Items.AllItemsReceived;
+                    var toRemove = new System.Collections.Generic.HashSet<int>();
+                    for (int i = 0; i < allItems.Count; i++)
+                    {
+                        string name = allItems[i].ItemName;
+                        float sciAmt;
+                        if (name == null || !KSPArchipelagoPartsManager.TryGetScienceAmount(name, out sciAmt))
+                            toRemove.Add(i);
+                    }
+                    scenario.AwardedItemIndices.ExceptWith(toRemove);
+                }
                 KSPArchipelagoPartsManager.ScrubTechTree();
                 KSPArchipelagoPartsManager.ClearAllExperimentalParts();
                 mod.ResetProgressiveState();

--- a/KSPArchipelago/KSPArchipelagoMod.cs
+++ b/KSPArchipelago/KSPArchipelagoMod.cs
@@ -26,6 +26,9 @@ namespace KSPArchipelago
         // Populated from slot_data at connect time.
         private static Dictionary<string, float> SciencePackAmounts = new Dictionary<string, float>();
 
+        public static bool TryGetScienceAmount(string itemName, out float amount)
+            => SciencePackAmounts.TryGetValue(itemName, out amount);
+
         /// <summary>
         /// Parse science pack definitions from slot_data. Returns true on success.
         /// </summary>
@@ -50,21 +53,15 @@ namespace KSPArchipelago
         /// </summary>
         public static void GiveItem(string itemName, string senderName,
                                     string locationName,
-                                    bool showToast = true,
-                                    bool awardScience = true)
+                                    bool showToast = true)
         {
             string toastText;
 
-            // Science packs: add science points directly.
+            // Science packs: toast only. R&D award and TotalApScienceAwarded are
+            // written together by the caller (ProcessAllItems / ProcessNewItems) so
+            // all three happen at once and can't desync
             if (SciencePackAmounts.TryGetValue(itemName, out float amount))
             {
-                if (awardScience)
-                {
-                    if (ResearchAndDevelopment.Instance != null)
-                        ResearchAndDevelopment.Instance.AddScience(amount, TransactionReasons.Cheating);
-                    if (ApScenarioModule.Instance != null)
-                        ApScenarioModule.Instance.TotalApScienceAwarded += amount;
-                }
                 if (showToast)
                 {
                     toastText = $"AP: Received {itemName} (+{amount} science)";
@@ -614,31 +611,45 @@ namespace KSPArchipelago
         {
             if (session == null) return;
 
+            var scenario = ApScenarioModule.Instance;
+            if (scenario == null)
+            {
+                Debug.LogWarning("[KSP-AP] ProcessAllItems: ApScenarioModule not ready, skipping");
+                return;
+            }
+
             var allItems = session.Items.AllItemsReceived;
-            var awarded = ApScenarioModule.Instance?.AwardedItemIndices;
+            var awarded = scenario.AwardedItemIndices;
             int count = allItems.Count;
 
-            Debug.Log($"[KSP-AP] ProcessAllItems: {count} items, {awarded?.Count ?? 0} previously awarded");
+            Debug.Log($"[KSP-AP] ProcessAllItems: {count} items, {awarded.Count} previously awarded");
 
             for (int i = 0; i < count; i++)
             {
                 var item = allItems[i];
                 if (item.ItemName == null) continue;
 
-                bool alreadyAwarded = awarded != null && awarded.Contains(i);
+                bool alreadyAwarded = awarded.Contains(i);
                 KSPArchipelagoPartsManager.GiveItem(
                     item.ItemName, item.Player?.Alias, item.LocationName,
-                    showToast: !alreadyAwarded,
-                    awardScience: !alreadyAwarded);
+                    showToast: !alreadyAwarded);
 
                 if (!alreadyAwarded)
-                    awarded?.Add(i);
+                {
+                    awarded.Add(i);
+                    if (KSPArchipelagoPartsManager.TryGetScienceAmount(item.ItemName, out float sciAmt))
+                    {
+                        if (ResearchAndDevelopment.Instance != null)
+                            ResearchAndDevelopment.Instance.AddScience(sciAmt, TransactionReasons.Cheating);
+                        scenario.TotalApScienceAwarded += sciAmt;
+                    }
+                }
             }
 
             _lastProcessedIndex = count;
             ItemsReceivedCount = count;
 
-            Debug.Log($"[KSP-AP] ProcessAllItems complete: {awarded?.Count ?? 0} total awarded");
+            Debug.Log($"[KSP-AP] ProcessAllItems complete: {awarded.Count} total awarded");
         }
 
         /// <summary>
@@ -648,8 +659,11 @@ namespace KSPArchipelago
         {
             if (session == null) return;
 
+            var scenario = ApScenarioModule.Instance;
+            if (scenario == null) return;
+
             var allItems = session.Items.AllItemsReceived;
-            var awarded = ApScenarioModule.Instance?.AwardedItemIndices;
+            var awarded = scenario.AwardedItemIndices;
             int count = allItems.Count;
 
             if (count <= _lastProcessedIndex) return;
@@ -661,9 +675,15 @@ namespace KSPArchipelago
 
                 KSPArchipelagoPartsManager.GiveItem(
                     item.ItemName, item.Player?.Alias, item.LocationName,
-                    showToast: true, awardScience: true);
+                    showToast: true);
 
-                awarded?.Add(i);
+                awarded.Add(i);
+                if (KSPArchipelagoPartsManager.TryGetScienceAmount(item.ItemName, out float sciAmt))
+                {
+                    if (ResearchAndDevelopment.Instance != null)
+                        ResearchAndDevelopment.Instance.AddScience(sciAmt, TransactionReasons.Cheating);
+                    scenario.TotalApScienceAwarded += sciAmt;
+                }
                 ItemsReceivedCount++;
                 OnItemReceived?.Invoke(item.ItemName);
             }

--- a/KSPArchipelago/KSPArchipelagoMod.cs
+++ b/KSPArchipelago/KSPArchipelagoMod.cs
@@ -293,6 +293,9 @@ namespace KSPArchipelago
         {
             if (session == null || ResearchAndDevelopment.Instance == null) return;
 
+            var scenario = ApScenarioModule.Instance;
+            if (scenario == null) return;
+
             float expectedScience = 0f;
             foreach (var item in session.Items.AllItemsReceived)
             {
@@ -300,14 +303,13 @@ namespace KSPArchipelago
                     expectedScience += amount;
             }
 
-            float alreadyAwarded = ApScenarioModule.Instance?.TotalApScienceAwarded ?? 0f;
+            float alreadyAwarded = scenario.TotalApScienceAwarded;
             float delta = expectedScience - alreadyAwarded;
 
             if (delta > 0.01f)
             {
                 ResearchAndDevelopment.Instance.AddScience(delta, TransactionReasons.Cheating);
-                if (ApScenarioModule.Instance != null)
-                    ApScenarioModule.Instance.TotalApScienceAwarded = expectedScience;
+                scenario.TotalApScienceAwarded = expectedScience;
                 Debug.Log($"[KSP-AP] ReconcileApScience: expected={expectedScience}, awarded={alreadyAwarded}, delta={delta}");
             }
             else

--- a/KSPArchipelago/KSPArchipelagoMod.cs
+++ b/KSPArchipelago/KSPArchipelagoMod.cs
@@ -308,7 +308,7 @@ namespace KSPArchipelago
 
             if (delta > 0.01f)
             {
-                ResearchAndDevelopment.Instance.AddScience(delta, TransactionReasons.Cheating);
+                /// ResearchAndDevelopment.Instance.AddScience(delta, TransactionReasons.Cheating);
                 Debug.Log($"[KSP-AP] ReconcileApScience: expected={expectedScience}, awarded={alreadyAwarded}, delta={delta}");
             }
             else

--- a/KSPArchipelago/KSPArchipelagoMod.cs
+++ b/KSPArchipelago/KSPArchipelagoMod.cs
@@ -309,7 +309,6 @@ namespace KSPArchipelago
             if (delta > 0.01f)
             {
                 ResearchAndDevelopment.Instance.AddScience(delta, TransactionReasons.Cheating);
-                scenario.TotalApScienceAwarded = expectedScience;
                 Debug.Log($"[KSP-AP] ReconcileApScience: expected={expectedScience}, awarded={alreadyAwarded}, delta={delta}");
             }
             else

--- a/KSPArchipelago/KSPArchipelagoMod.cs
+++ b/KSPArchipelago/KSPArchipelagoMod.cs
@@ -612,30 +612,31 @@ namespace KSPArchipelago
         {
             if (session == null) return;
 
+            // ApScenarioModule is not registered for the EDITOR scene. KSP fires
+            // onGameStateLoad when entering the VAB, which triggers this path with
+            // Instance == null. Do NOT bail — GiveItem must still run so parts are
+            // re-added after ClearAllExperimentalParts. Skip science tracking only
+            // when the scenario is unavailable to avoid double-awarding on the next
+            // call when it is available.
             var scenario = ApScenarioModule.Instance;
-            if (scenario == null)
-            {
-                Debug.LogWarning("[KSP-AP] ProcessAllItems: ApScenarioModule not ready, skipping");
-                return;
-            }
+            var awarded = scenario?.AwardedItemIndices;
 
             var allItems = session.Items.AllItemsReceived;
-            var awarded = scenario.AwardedItemIndices;
             int count = allItems.Count;
 
-            Debug.Log($"[KSP-AP] ProcessAllItems: {count} items, {awarded.Count} previously awarded");
+            Debug.Log($"[KSP-AP] ProcessAllItems: {count} items, {awarded?.Count ?? 0} previously awarded");
 
             for (int i = 0; i < count; i++)
             {
                 var item = allItems[i];
                 if (item.ItemName == null) continue;
 
-                bool alreadyAwarded = awarded.Contains(i);
+                bool alreadyAwarded = awarded != null && awarded.Contains(i);
                 KSPArchipelagoPartsManager.GiveItem(
                     item.ItemName, item.Player?.Alias, item.LocationName,
                     showToast: !alreadyAwarded);
 
-                if (!alreadyAwarded)
+                if (!alreadyAwarded && scenario != null)
                 {
                     awarded.Add(i);
                     if (KSPArchipelagoPartsManager.TryGetScienceAmount(item.ItemName, out float sciAmt))
@@ -650,7 +651,7 @@ namespace KSPArchipelago
             _lastProcessedIndex = count;
             ItemsReceivedCount = count;
 
-            Debug.Log($"[KSP-AP] ProcessAllItems complete: {awarded.Count} total awarded");
+            Debug.Log($"[KSP-AP] ProcessAllItems complete: {awarded?.Count ?? 0} total awarded");
         }
 
         /// <summary>

--- a/KSPArchipelago/KSPArchipelagoMod.cs
+++ b/KSPArchipelago/KSPArchipelagoMod.cs
@@ -674,19 +674,23 @@ namespace KSPArchipelago
                 var item = allItems[i];
                 if (item.ItemName == null) continue;
 
+                bool alreadyAwarded = awarded.Contains(i);
                 KSPArchipelagoPartsManager.GiveItem(
                     item.ItemName, item.Player?.Alias, item.LocationName,
-                    showToast: true);
+                    showToast: !alreadyAwarded);
 
-                awarded.Add(i);
-                if (KSPArchipelagoPartsManager.TryGetScienceAmount(item.ItemName, out float sciAmt))
+                if (!alreadyAwarded)
                 {
-                    if (ResearchAndDevelopment.Instance != null)
-                        ResearchAndDevelopment.Instance.AddScience(sciAmt, TransactionReasons.Cheating);
-                    scenario.TotalApScienceAwarded += sciAmt;
+                    awarded.Add(i);
+                    if (KSPArchipelagoPartsManager.TryGetScienceAmount(item.ItemName, out float sciAmt))
+                    {
+                        if (ResearchAndDevelopment.Instance != null)
+                            ResearchAndDevelopment.Instance.AddScience(sciAmt, TransactionReasons.Cheating);
+                        scenario.TotalApScienceAwarded += sciAmt;
+                    }
+                    OnItemReceived?.Invoke(item.ItemName);
                 }
                 ItemsReceivedCount++;
-                OnItemReceived?.Invoke(item.ItemName);
             }
 
             _lastProcessedIndex = count;


### PR DESCRIPTION
Attempt to fix issues https://github.com/nickdavies/KSP1-Archipelago-client/issues/4 and https://github.com/nickdavies/KSP1-Archipelago-client/issues/5

Moves all science handling to the `ProcessAllItems` and `ProcessNewItems` methods so the science points are added and the flags in the save file are set atomically.

Modified the 'Re-Award All Items' button to skip the science check. Now, it just compares the received science items from the AP server against what is present in the save file.

Verified that this fixes the bugs described in #4 and #5.
Also verified that persistence between saves in this version works:
1. Make a save
2. In the AP console, `/send Baker science pack 1`
2. Load the save, and the science award from the item is properly re-applied